### PR TITLE
[Fix] issue119: prevent markup beautification on text nodes

### DIFF
--- a/lib/markuppretty.js
+++ b/lib/markuppretty.js
@@ -776,6 +776,23 @@ var summary      = "",
                     token.push(element.replace(/\s+/g, " "));
                 }
             },
+            isContentWithPresidingSpace = function markuppretty__CheckIfSpaceStartsContent(startIndex){
+				if (b[startIndex-1] ===">"){
+					var endIndex = b.indexOf("<",startIndex);
+						if (endIndex === -1) {
+							return false; // no starting tag was found. it is just a space.
+                        } else {
+							var sProposedContent = b.slice(startIndex,endIndex).join("");
+                            if (sProposedContent.search(/[^\s\t\n]/) === -1){
+								return false;
+                            } else {
+								return true; //there is content after the space and before '<', thus - a content node
+                            }
+						}
+                }else {
+					return false; // not started after a '>' tag, so just a space
+                }
+            },
             content  = function markuppretty__tokenize_content() {
                 var output    = [],
                     quote     = "",
@@ -851,7 +868,7 @@ var summary      = "",
                         if (mcont === true) {
                             token.push("text");
                         } else {
-                            token.push(output.join("").replace(/(\s+)$/, tailSpace).replace(/\s+/g, " "));
+                            token.push(output.join(""));
                         }
                         return types.push("content");
                     }
@@ -863,9 +880,14 @@ var summary      = "",
             if (ext === true) {
                 content();
             } else if ((/\s/).test(b[a]) === true) {
-                space = space + b[a];
-                if (b[a] === "\n") {
-                    line += 1;
+                var isContent = isContentWithPresidingSpace(a);
+                if (isContent){
+					content();
+                } else {
+					space = space + b[a];
+					if (b[a] === "\n") {
+						line += 1;
+					}                
                 }
             } else if (b[a] === "<") {
                 tag("");


### PR DESCRIPTION
when markup beautifying text nodes (<xml> abc <\xml> fix the followings:
keep space/s chars at the beginning of the node
prevent removal of spaces and control (newLine, tab) at the end of the node
does not enter indent/new-line inside the text node

This fix doesn't fix the following problem:
When there are nested nodes inside the node which contains also text-node, the text-node gets indented.