### PR TITLE
fixed issue where ternaryline=true would incorrectly decrement indent…

### DIFF
--- a/lib/jspretty.js
+++ b/lib/jspretty.js
@@ -2312,7 +2312,9 @@ var jspretty = function jspretty_(options) {
                                     }
                                 }
                             } else {
-                                indent -= 1;
+                                if(!options.ternaryline) {
+                                  indent -= 1;  
+                                }
                                 if (ctoke === ":" && ternary.length === 1) {
                                     lasttest = true;
                                     break;


### PR DESCRIPTION
…ion level

if ternaryline is set to true, the indention level is decremented causing all lines afterwards to be incorrectly indented. The comment attached to this shows what happens.