### PR TITLE
Fix Liquid comment & 'for' iteration tags glitch

### DIFF
--- a/lib/markuppretty.js
+++ b/lib/markuppretty.js
@@ -1190,13 +1190,18 @@
                         element = element
                             .replace(/^(\{%\s*comment\s*%\}\s*)/, "")
                             .replace(/(\s*\{%\s*endcomment\s*%\})$/, "");
+
+                        attrs.push({});
                         attrs.push({});
                         attrs.push({});
                         value.push("");
                         value.push("");
+                        value.push("");
+                        jscom.push(false);
                         jscom.push(false);
                         jscom.push(false);
                         e = linen[linen.length - 1];
+                        linen.push(e);
                         linen.push(e);
                         linen.push(e);
                         types[types.length - 1] = "template_start";

--- a/lib/markuppretty.js
+++ b/lib/markuppretty.js
@@ -2720,7 +2720,7 @@
                             item = item
                                 .replace(tab, "")
                                 .replace(/\)\s*and\s*\(/g, ") and (")
-                                .replace(/in\u0020\d+\.\u0020\.\d/g, fixnumb);
+                                .replace(/in\u0020?\(?\d+\.\u0020\.\d\(?/g, fixnumb);
                             if (options.correct === true) {
                                 item = item.replace(/;$/, "") + " %}";
                             } else {


### PR DESCRIPTION
Hey!

I found an issue with Liquid comment having glitch when running Beautify and/or Minify. This is code source to be beautified/minified
`{% comment %}
    This should be fail
{% endcomment %}
<div class="sample">
    Sample Content
</div>`

When running Beautify/Minify it throws an error : 
![issue](https://www.dropbox.com/s/htdwotbjpsbqdmg/Screenshot%202016-09-17%2001.08.47.png?dl=1)

This PR fix the issue, please review.