### PR TITLE
Fix whitespace removed from output when using diff_space_ignore

### DIFF
--- a/api/diffview.ts
+++ b/api/diffview.ts
@@ -48,6 +48,9 @@
                     c: number = 0,
                     d: number = 0,
                     codes: opcodes = [],
+                    clean = function diffview_opcodes_clean(ln:string): string {
+                        return options.diff_space_ignore === true ? ln.replace(/\s+/g, '') : ln;
+                    },
                     fix = function diffview_opcodes_fix(code:codes): void {
                         let len:number = codes.length - 1,
                             prior:[string, number, number, number, number] = codes[len];
@@ -251,9 +254,6 @@
                 // * First Pass, account for lines from first file
                 // * build the table from the second file
                 do {
-                    if (options.diff_space_ignore === true) {
-                        two[b] = two[b].replace(/\s+/g, "");
-                    }
                     if (table[two[b]] === undefined) {
                         table[two[b]] = [0, 1];
                     } else {
@@ -266,9 +266,6 @@
                 lena = one.length;
                 a = 0;
                 do {
-                    if (options.diff_space_ignore === true) {
-                        one[a] = one[a].replace(/\s+/g, "");
-                    }
                     if (table[one[a]] === undefined) {
                         table[one[a]] = [1, 0];
                     } else {
@@ -284,21 +281,21 @@
                 do {
                     c = a;
                     d = b;
-                    if (one[a] === two[b]) {
+                    if (clean(one[a]) === clean(two[b])) {
                         equality();
                     } else if (table[one[a]][1] < 1 && table[two[b]][0] < 1) {
                         replaceUniques();
-                    } else if (table[one[a]][1] < 1 && one[a + 1] !== two[b + 2]) {
+                    } else if (table[one[a]][1] < 1 && clean(one[a + 1]) !== clean(two[b + 2])) {
                         deletion();
-                    } else if (table[two[b]][0] < 1 && one[a + 2] !== two[b + 1]) {
+                    } else if (table[two[b]][0] < 1 && clean(one[a + 2]) !== clean(two[b + 1])) {
                         insertion();
-                    } else if (table[one[a]][0] - table[one[a]][1] === 1 && one[a + 1] !== two[b + 2]) {
+                    } else if (table[one[a]][0] - table[one[a]][1] === 1 && clean(one[a + 1]) !== clean(two[b + 2])) {
                         deletionStatic();
-                    } else if (table[two[b]][1] - table[two[b]][0] === 1 && one[a + 2] !== two[b + 1]) {
+                    } else if (table[two[b]][1] - table[two[b]][0] === 1 && clean(one[a + 2]) !== clean(two[b + 1])) {
                         insertionStatic();
-                    } else if (one[a + 1] === two[b]) {
+                    } else if (clean(one[a + 1]) === clean(two[b])) {
                         deletion();
-                    } else if (one[a] === two[b + 1]) {
+                    } else if (clean(one[a]) === clean(two[b + 1])) {
                         insertion();
                     } else {
                         replacement();

--- a/api/diffview.ts
+++ b/api/diffview.ts
@@ -47,7 +47,8 @@
                     c: number = 0,
                     d: number = 0,
                     codes: opcodes = [],
-                    clean = function diffview_opcodes_clean(ln:string): string {
+                    clean = function diffview_opcodes_clean(ln:string): string|void {
+                        if (ln === undefined) { return; }
                         return options.diff_space_ignore === true ? ln.replace(/\s+/g, '') : ln;
                     },
                     fix = function diffview_opcodes_fix(code:codes): void {
@@ -64,7 +65,7 @@
                                     prior[4] = code[4];
                                 }
                                 if (codes.length > 1 && prior[2] === code[2] && prior[4] === code[4]) {
-                                    if (prior[0] === "insert" && two[codes[codes.length - 2][4] - (prior[4] - prior[3])] === one[codes[codes.length - 2][1]]) {
+                                    if (prior[0] === "insert" && clean(two[codes[codes.length - 2][4] - (prior[4] - prior[3])]) === clean(one[codes[codes.length - 2][1]])) {
                                         codes.pop();
                                         len = len - 1;
                                         codes[len] = ["insert", -1, -1, codes[len][3], codes[len][4] - (prior[4] - prior[3])];
@@ -188,7 +189,7 @@
                             table[one[c]][1] = table[one[c]][1] - 1;
                             c = c + 1;
                             d = d + 1;
-                        } while (c < lena && d < lenb && one[c] === two[d]);
+                        } while (c < lena && d < lenb && clean(one[c]) === clean(two[d]));
                         fix(["equal", a, c, b, d]);
                         b = d - 1;
                         a = c - 1;
@@ -303,7 +304,7 @@
                     b = b + 1;
                 } while (a < lena && b < lenb);
                 if (lena - a === lenb - b) {
-                    if (one[a] === two[b]) {
+                    if (clean(one[a]) === clean(two[b])) {
                         fix(["equal", a, lena, b, lenb]);
                     } else {
                         fix(["replace", a, lena, b, lenb]);

--- a/tests/diffbase/diff_html_diffSpaceIgnore.txt
+++ b/tests/diffbase/diff_html_diffSpaceIgnore.txt
@@ -1,0 +1,3 @@
+<!--prettydiff.com diff_space_ignore:true -->
+<div>
+</div>

--- a/tests/diffbase/diff_html_diffSpaceIgnore.txt
+++ b/tests/diffbase/diff_html_diffSpaceIgnore.txt
@@ -1,3 +1,3 @@
 <!--prettydiff.com diff_space_ignore:true -->
-<div>
-</div>
+<p id="whitespace-only" class="whitespace only">Whitespace only</p>
+<p></p>

--- a/tests/diffnew/diff_html_diffSpaceIgnore.txt
+++ b/tests/diffnew/diff_html_diffSpaceIgnore.txt
@@ -1,0 +1,3 @@
+<!--prettydiff.com diff_space_ignore:true -->
+<div id="hello" class="hiya bubbaye">Hi, world!
+</div>

--- a/tests/diffnew/diff_html_diffSpaceIgnore.txt
+++ b/tests/diffnew/diff_html_diffSpaceIgnore.txt
@@ -1,3 +1,4 @@
 <!--prettydiff.com diff_space_ignore:true -->
-<div id="hello" class="hiya bubbaye">Hi, world!
+<div id="hello" class="hiya laterz">
+  Hi, world!
 </div>

--- a/tests/diffnew/diff_html_diffSpaceIgnore.txt
+++ b/tests/diffnew/diff_html_diffSpaceIgnore.txt
@@ -1,4 +1,3 @@
 <!--prettydiff.com diff_space_ignore:true -->
-<div id="hello" class="hiya laterz">
-  Hi, world!
-</div>
+<p  id="whitespace-only"  class="whitespace only">Whitespace only</p>
+<p id="diff">Add id and text</p>

--- a/tests/simulations.ts
+++ b/tests/simulations.ts
@@ -206,6 +206,11 @@
                 test: "folds from line XXXX to line 2"
             },
             {
+                command: `diff source:"${projectPath}tests${sep}diffbase${sep}diff_html_diffSpaceIgnore.txt" diff:"${projectPath}tests${sep}diffnew${sep}diff_html_diffSpaceIgnore.txt" read_method:file`,
+                qualifier: "contains",
+                test: `${text.green}<div${text.diffchar}class="h${text.clear}i${text.diffchar}yabubbaye"id="hello"${text.clear}>${text.diffchar}Hi,world!${text.clear}`
+            },
+            {
                 command: `diff source:"hello" diff:"shelo" readmethod:screen`,
                 qualifier: "contains",
                 test: `${text.cyan}Line: 1${text.none}\n${text.red}hel${text.diffchar}l${text.clear}o${text.none}\n${text.green + text.diffchar}s${text.clear}helo${text.none}`

--- a/tests/simulations.ts
+++ b/tests/simulations.ts
@@ -208,7 +208,7 @@
             {
                 command: `diff source:"${projectPath}tests${sep}diffbase${sep}diff_html_diffSpaceIgnore.txt" diff:"${projectPath}tests${sep}diffnew${sep}diff_html_diffSpaceIgnore.txt" read_method:file`,
                 qualifier: "contains",
-                test: `${text.green}<div${text.diffchar}class="h${text.clear}i${text.diffchar}yabubbaye"id="hello"${text.clear}>${text.diffchar}Hi,world!${text.clear}`
+                test: `${text.green}<div class="hiya laterz" id="hello">${text.none}\n${text.green}Hi, world!${text.none}`
             },
             {
                 command: `diff source:"hello" diff:"shelo" readmethod:screen`,

--- a/tests/simulations.ts
+++ b/tests/simulations.ts
@@ -208,7 +208,7 @@
             {
                 command: `diff source:"${projectPath}tests${sep}diffbase${sep}diff_html_diffSpaceIgnore.txt" diff:"${projectPath}tests${sep}diffnew${sep}diff_html_diffSpaceIgnore.txt" read_method:file`,
                 qualifier: "contains",
-                test: `${text.green}<div class="hiya laterz" id="hello">${text.none}\n${text.green}Hi, world!${text.none}`
+                test: `${text.red}<p></p>${text.none}\n${text.green}<p${text.diffchar} id="diff"${text.clear}>${text.diffchar}Add id and text${text.clear}</p>${text.none}`
             },
             {
                 command: `diff source:"hello" diff:"shelo" readmethod:screen`,


### PR DESCRIPTION
Before attempting to fix the issue in #585, I'm trying to add a simulation test but struggling to get the message correct. The current test message doesn't have any white-space (wrong outcome, using it to learn the test setup).

This is the error message I'm getting after `npm test`:

```
Error Message
------------
Simulation test string diff source:"/Users/sarah/Projects/prettydiff/tests/diffbase/diff_html_diffSpaceIgnore.txt" diff:"/Users/sarah/Projects/prettydiff/tests/diffnew/diff_html_diffSpaceIgnore.txt" read_method:file does not contain the expected output:
<div[1mclass="h[24mi[1myabubbaye"id="hello"[24m>[1mHi,world![24m


Actual output:
Line: 2
<div></div>
<divclass="hiyabubbaye"id="hello">Hi,world!
</div>


Pretty Diff found 1 difference on 2 lines.
```