### PR TITLE
Remove Typescript global dep

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,17 @@
-node_modules
+# Source code
+api/
+beautify/
+minify/
+tests/
+serviceWorker.txt
+*.ts
+tsconfig.json
+
+# Node modules
+node_modules/
+
+# Project configuration
+.appveyor.yml
+.eslintrc.json
+.github/
+.gitignore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ test_script:
   - npm cache clean --force
   - rm -f package-lock.json
   - npm install
-  - npm install --dev typescript@latest
-  - node_modules\.bin\tsc --pretty
   - node js/services build local
   # run tests
   - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "prettydiff",
-    "version": "101.1.1",
+    "version": "101.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,10 +35,9 @@
             }
         },
         "typescript": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
-            "dev": true
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
         },
         "ws": {
             "version": "5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,12 @@
                 "@types/node": "^10.12.27"
             }
         },
+        "typescript": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+            "dev": true
+        },
         "ws": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "prettydiff",
-    "version": "101.1.8",
+    "version": "101.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     },
     "dependencies": {
         "file-saver": "^1.3.8",
-        "sparser": "^1.4.4"
+        "sparser": "^1.4.4",
+        "typescript": "^3.5.3"
     },
     "description": "A language aware diff tool.",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
         "url": "https://github.com/prettydiff/prettydiff/issues"
     },
     "dependencies": {
-        "@types/node": "^10.14.7",
         "file-saver": "^1.3.8",
         "sparser": "^1.3.1"
     },
     "description": "A language aware diff tool.",
     "devDependencies": {
+        "@types/node": "^10.14.7",
         "ace-builds": "^1.4.4",
         "typescript": "^3.5.2",
         "ws": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "description": "A language aware diff tool.",
     "devDependencies": {
         "ace-builds": "^1.4.4",
+        "typescript": "^3.5.2",
         "ws": "^5.2.2"
     },
     "directories": {
@@ -35,6 +36,7 @@
         "url": "git+https://github.com/prettydiff/prettydiff.git"
     },
     "scripts": {
+        "postinstall": "tsc --pretty",
         "prepublishOnly": "node js/services test",
         "start": "node js/services build",
         "test": "node js/services test"

--- a/readme.md
+++ b/readme.md
@@ -14,10 +14,8 @@ Version - 101.1.3
 git clone https://github.com/prettydiff/prettydiff.git
 cd prettydiff
 
-npm install typescript -g
 npm install eslint -g
 npm install
-tsc --pretty
 
 node js/services build
 ```
@@ -38,10 +36,9 @@ npm test
 ```
 
 ### Global install with NPM
-The instructions for installing Pretty Diff globally via NPM do not indicate installing ESLint or Typescript, but the build and test commands will not work without them.
+The instructions for installing Pretty Diff globally via NPM do not indicate installing ESLint but the build and test commands will not work without them.
 
 ```
-npm install -g typescript
 npm install -g eslint
 prettydiff test
 ```

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ npm test
 ```
 
 ### Global install with NPM
-The instructions for installing Pretty Diff globally via NPM do not indicate installing ESLint but the build and test commands will not work without them.
+The instructions for installing Pretty Diff globally via NPM do not indicate installing ESLint but the build and test commands will not work without it.
 
 ```
 npm install -g eslint

--- a/tests/simulations.ts
+++ b/tests/simulations.ts
@@ -48,7 +48,7 @@
                 test: "No path to encode."
             },
             {
-                command: `base64 ${projectPath}tsconfig.json`,
+                command: `base64 ${projectPath}tests${sep}tsconfig.json`,
                 qualifier: "is",
                 test: "ewogICAgImNvbXBpbGVyT3B0aW9ucyI6IHsKICAgICAgICAib3V0RGlyIjogImpzIiwKICAgICAgICAicHJldHR5IjogdHJ1ZSwKICAgICAgICAidGFyZ2V0IjogIkVTNiIKICAgIH0sCiAgICAiaW5jbHVkZSI6IFsKICAgICAgICAiKi50cyIsCiAgICAgICAgIioqLyoudHMiCiAgICBdLAogICAgImV4Y2x1ZGUiOiBbCiAgICAgICAgIjIiLAogICAgICAgICIzIiwKICAgICAgICAianMiLAogICAgICAgICJpZ25vcmUiLAogICAgICAgICJub2RlX21vZHVsZXMiCiAgICBdCn0="
             },
@@ -95,22 +95,22 @@
                 test: ` files written to ${text.cyan + projectPath}test${text.none}.`
             },
             {
-                command: `beautify source:"${projectPath}tsconfig.json" read_method:directory`,
+                command: `beautify source:"${projectPath}tests${sep}tsconfig.json" read_method:directory`,
                 qualifier: "contains",
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}directory${text.none} but ${text.angry}option source does not point to a directory${text.none}.`
             },
             {
-                command: `beautify source:"${projectPath}tsconfig.json" read_method:file`,
+                command: `beautify source:"${projectPath}tests${sep}tsconfig.json" read_method:file`,
                 qualifier: "is",
                 test: `{\n    "compilerOptions": {\n        "outDir": "js",\n        "pretty": true,\n        "target": "ES6"\n    },\n    "include": [\n        "*.ts", "**/*.ts"\n    ],\n    "exclude": ["2", "3", "js", "ignore", "node_modules"]\n}`
             },
             {
-                command: `beautify source:"${projectPath}tsconfig.json" read_method:file language:text`,
+                command: `beautify source:"${projectPath}tests${sep}tsconfig.json" read_method:file language:text`,
                 qualifier: "contains",
                 test: `Language value ${text.angry}text${text.none} is not compatible with command ${text.green}beautify${text.none}.`
             },
             {
-                command: `beautify source:"${projectPath}tsconfig.json" read_method:subdirectory`,
+                command: `beautify source:"${projectPath}tests${sep}tsconfig.json" read_method:subdirectory`,
                 qualifier: "contains",
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}subdirectory${text.none} but ${text.angry}option source does not point to a directory${text.none}.`
             },
@@ -290,24 +290,24 @@
                 test: `${sep}asdf${text.none} is not a file or directory.`
             },
             {
-                command: `hash ${projectPath}tsconfig.json`,
+                command: `hash ${projectPath}tests${sep}tsconfig.json`,
                 qualifier: "is",
                 test: "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
             },
             {
-                command: `hash ${projectPath}tsconfig.json --verbose`,
+                command: `hash ${projectPath}tests${sep}tsconfig.json --verbose`,
                 qualifier: "contains",
                 test: "Sparser version "
             },
             {
                 command: `hash ${projectPath} list ignore ["node_modules", ".git", ".DS_Store", "2", "3", "beta", "ignore", "sparser"]`,
                 qualifier: "contains",
-                test: `tsconfig.json":"8546bfec8ef3570fbd4b4346d5dd68893eba57af2e1ecf835c248ddf1cfb39ffa2a2603060c48ec97f11c0891055bdfadec95d922db887ceea169d88e53f775e"`
+                test: `tsconfig.json":"19dfdba0b65a45ce3d27be1720acf98835cda3b0059da7672df3e5146e81af23fefc86532819f3798c50e1a716f0971a40ed27ca103fb288667d631997f80bc4"`
             },
             {
                 command: `hash ${projectPath} list ignore [.git, "node_modules", ".DS_Store", "2", "3", "beta", "ignore", "sparser", "tests", "js", "api", "beautify", "minify", "css", 'space test']`,
                 qualifier: "contains",
-                test: `tsconfig.json":"8546bfec8ef3570fbd4b4346d5dd68893eba57af2e1ecf835c248ddf1cfb39ffa2a2603060c48ec97f11c0891055bdfadec95d922db887ceea169d88e53f775e"`
+                test: `tsconfig.json":"19dfdba0b65a45ce3d27be1720acf98835cda3b0059da7672df3e5146e81af23fefc86532819f3798c50e1a716f0971a40ed27ca103fb288667d631997f80bc4"`
             },
             {
                 command: `hash ${projectPath} list ignore [.git, "node_modules", ".DS_Store", "2", "3", "beta", "ignore", "sparser", "tests", "js", "api", "beautify", "minify", "css", "space test", "test"]`,
@@ -340,22 +340,22 @@
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}file${text.none} but ${text.angry}option source does not point to a file${text.none}.`
             },
             {
-                command: `minify source:"${projectPath}tsconfig.json" read_method:directory`,
+                command: `minify source:"${projectPath}tests${sep}tsconfig.json" read_method:directory`,
                 qualifier: "contains",
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}directory${text.none} but ${text.angry}option source does not point to a directory${text.none}.`
             },
             {
-                command: `minify source:"${projectPath}tsconfig.json" read_method:file`,
+                command: `minify source:"${projectPath}tests${sep}tsconfig.json" read_method:file`,
                 qualifier: "is",
                 test: `{"compilerOptions":{"outDir":"js","pretty":true,"target":"ES6"},"include":["*.ts","**/*.ts"],"exclude":["2","3","js","ignore","node_modules"]}`
             },
             {
-                command: `minify source:"${projectPath}tsconfig.json" read_method:file language:text`,
+                command: `minify source:"${projectPath}tests${sep}tsconfig.json" read_method:file language:text`,
                 qualifier: "contains",
                 test: `Language value ${text.angry}text${text.none} is not compatible with command ${text.green}minify${text.none}.`
             },
             {
-                command: `minify source:"${projectPath}tsconfig.json" read_method:subdirectory`,
+                command: `minify source:"${projectPath}tests${sep}tsconfig.json" read_method:subdirectory`,
                 qualifier: "contains",
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}subdirectory${text.none} but ${text.angry}option source does not point to a directory${text.none}.`
             },
@@ -415,35 +415,35 @@
                 test: `Pretty Diff requires option ${text.cyan}source${text.none} when using command ${text.green}parse${text.none}. Example:`
             },
             {
-                command: `parse ${projectPath}tsconfig.json`,
+                command: `parse ${projectPath}tests${sep}tsconfig.json`,
                 qualifier: "contains",
                 test:  `{"begin":[-1,0,0,0,3,3,3,3,3,3,3,3,3,3,3,3,0,0,0,0,19,19,19,19,0,0,0,0,27,27,27,27,27,27,27,27,27,27,0],"ender":[38,38,38,15,15,15,15,15,15,15,15,15,15,15,15,15,38,38,38,23,23,23,23,23,38,38,38,37,37,37,37,37,37,37,37,37,37,37,38],"lexer":["script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script"],"lines":[0,2,0,1,2,0,1,0,2,0,1,0,2,0,1,2,0,2,0,1,2,0,2,2,0,2,0,1,2,0,2,0,2,0,2,0,2,2,2],"stack":["global","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","array","array","array","array","object","object","object","object","array","array","array","array","array","array","array","array","array","array","object"],"token":["{","\\"compilerOptions\\"",":","{","\\"outDir\\"",":","\\"js\\"",",","\\"pretty\\"",":","true",",","\\"target\\"",":","\\"ES6\\"","}",",","\\"include\\"",":","[","\\"*.ts\\"",",","\\"**/*.ts\\"","]",",","\\"exclude\\"",":","[","\\"2\\"",",","\\"3\\"",",","\\"js\\"",",","\\"ignore\\"",",","\\"node_modules\\"","]","}"],"types":["start","string","operator","start","string","operator","string","separator","string","operator","word","separator","string","operator","string","end","separator","string","operator","start","string","separator","string","end","separator","string","operator","start","string","separator","string","separator","string","separator","string","separator","string","end","end"]}`
             },
             {
-                command: `parse ${projectPath}tsconfig.json parse_format:table`,
+                command: `parse ${projectPath}tests${sep}tsconfig.json parse_format:table`,
                 qualifier: "contains",
-                test: `Parsed input from file ${text.cyan + projectPath}tsconfig.json${text.none}`
+                test: `Parsed input from file ${text.cyan + projectPath}tests${sep}tsconfig.json${text.none}`
             },
             {
-                command: `parse ${projectPath}tsconfig.json parse_format:table 2`,
+                command: `parse ${projectPath}tests${sep}tsconfig.json parse_format:table 2`,
                 qualifier: "contains",
                 test: `index | begin | ender | lexer  | lines | stack       | types       | token\n------|-------|-------|--------|-------|-------------|-------------|------\n${text.green}0     | -1    | XXXX    | script | XXXX     | global      | start       | {${text.none}`
             },
             {
                 artifact: `${projectPath}parsetest.txt`,
-                command: `parse ${projectPath}tsconfig.json read_method:file output:"parsetest.txt"`,
+                command: `parse ${projectPath}tests${sep}tsconfig.json read_method:file output:"parsetest.txt"`,
                 file: `${projectPath}parsetest.txt`,
                 qualifier: "file is",
                 test:  `{"begin":[-1,0,0,0,3,3,3,3,3,3,3,3,3,3,3,3,0,0,0,0,19,19,19,19,0,0,0,0,27,27,27,27,27,27,27,27,27,27,0],"ender":[38,38,38,15,15,15,15,15,15,15,15,15,15,15,15,15,38,38,38,23,23,23,23,23,38,38,38,37,37,37,37,37,37,37,37,37,37,37,38],"lexer":["script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script"],"lines":[0,2,0,1,2,0,1,0,2,0,1,0,2,0,1,2,0,2,0,1,2,0,2,2,0,2,0,1,2,0,2,0,2,0,2,0,2,2,2],"stack":["global","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","array","array","array","array","object","object","object","object","array","array","array","array","array","array","array","array","array","array","object"],"token":["{","\\"compilerOptions\\"",":","{","\\"outDir\\"",":","\\"js\\"",",","\\"pretty\\"",":","true",",","\\"target\\"",":","\\"ES6\\"","}",",","\\"include\\"",":","[","\\"*.ts\\"",",","\\"**/*.ts\\"","]",",","\\"exclude\\"",":","[","\\"2\\"",",","\\"3\\"",",","\\"js\\"",",","\\"ignore\\"",",","\\"node_modules\\"","]","}"],"types":["start","string","operator","start","string","operator","string","separator","string","operator","word","separator","string","operator","string","end","separator","string","operator","start","string","separator","string","end","separator","string","operator","start","string","separator","string","separator","string","separator","string","separator","string","end","end"]}`
             },
             {
                 artifact: `${projectPath}parsetest.txt`,
-                command: `parse ${projectPath}tsconfig.json read_method:file output:"${projectPath}parsetest.txt"`,
+                command: `parse ${projectPath}tests${sep}tsconfig.json read_method:file output:"${projectPath}parsetest.txt"`,
                 qualifier: "begins",
                 test: `Wrote output to ${text.green + projectPath}parsetest.txt${text.none} at`
             },
             {
-                command: `parse ${projectPath}tsconfig.json read_method:file`,
+                command: `parse ${projectPath}tests${sep}tsconfig.json read_method:file`,
                 qualifier: "is",
                 test:  `{"begin":[-1,0,0,0,3,3,3,3,3,3,3,3,3,3,3,3,0,0,0,0,19,19,19,19,0,0,0,0,27,27,27,27,27,27,27,27,27,27,0],"ender":[38,38,38,15,15,15,15,15,15,15,15,15,15,15,15,15,38,38,38,23,23,23,23,23,38,38,38,37,37,37,37,37,37,37,37,37,37,37,38],"lexer":["script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script","script"],"lines":[0,2,0,1,2,0,1,0,2,0,1,0,2,0,1,2,0,2,0,1,2,0,2,2,0,2,0,1,2,0,2,0,2,0,2,0,2,2,2],"stack":["global","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","object","array","array","array","array","object","object","object","object","array","array","array","array","array","array","array","array","array","array","object"],"token":["{","\\"compilerOptions\\"",":","{","\\"outDir\\"",":","\\"js\\"",",","\\"pretty\\"",":","true",",","\\"target\\"",":","\\"ES6\\"","}",",","\\"include\\"",":","[","\\"*.ts\\"",",","\\"**/*.ts\\"","]",",","\\"exclude\\"",":","[","\\"2\\"",",","\\"3\\"",",","\\"js\\"",",","\\"ignore\\"",",","\\"node_modules\\"","]","}"],"types":["start","string","operator","start","string","operator","string","separator","string","operator","word","separator","string","operator","string","end","separator","string","operator","start","string","separator","string","end","separator","string","operator","start","string","separator","string","separator","string","separator","string","separator","string","end","end"]}`
             },
@@ -453,17 +453,17 @@
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}file${text.none} but ${text.angry}option source does not point to a file${text.none}.`
             },
             {
-                command: `parse source:"${projectPath}tsconfig.json" read_method:directory`,
+                command: `parse source:"${projectPath}tests${sep}tsconfig.json" read_method:directory`,
                 qualifier: "contains",
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}directory${text.none} but ${text.angry}option source does not point to a directory${text.none}.`
             },
             {
-                command: `parse source:"${projectPath}tsconfig.json" read_method:file language:text`,
+                command: `parse source:"${projectPath}tests${sep}tsconfig.json" read_method:file language:text`,
                 qualifier: "contains",
                 test: `Language value ${text.angry}text${text.none} is not compatible with command ${text.green}parse${text.none}.`
             },
             {
-                command: `parse source:"${projectPath}tsconfig.json" read_method:subdirectory`,
+                command: `parse source:"${projectPath}tests${sep}tsconfig.json" read_method:subdirectory`,
                 qualifier: "contains",
                 test: `Option ${text.cyan}read_method${text.none} has value ${text.green}subdirectory${text.none} but ${text.angry}option source does not point to a directory${text.none}.`
             },
@@ -525,12 +525,12 @@
 
             // final two tests validate the application and JSON formats of the .prettydiffrc file
             {
-                command: `beautify source:"${projectPath}tsconfig.json" prettydiffrc-json`,
+                command: `beautify source:"${projectPath}tests${sep}tsconfig.json" prettydiffrc-json`,
                 qualifier: "contains",
                 test: "\n      \"compilerOptions\":"
             },
             {
-                command: `beautify source:"${projectPath}tsconfig.json" prettydiffrc-javascript`,
+                command: `beautify source:"${projectPath}tests${sep}tsconfig.json" prettydiffrc-javascript`,
                 qualifier: "contains",
                 test: "\n        \"compilerOptions\":"
             }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -5,10 +5,14 @@
         "target": "ES6"
     },
     "include": [
+        "*.ts",
         "**/*.ts"
     ],
     "exclude": [
+        "2",
+        "3",
         "js",
+        "ignore",
         "node_modules"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
         "target": "ES6"
     },
     "include": [
-        "*.ts",
         "**/*.ts"
     ],
     "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,7 @@
         "**/*.ts"
     ],
     "exclude": [
-        "2",
-        "3",
         "js",
-        "node_modules",
-        "test"
+        "node_modules"
     ]
 }


### PR DESCRIPTION
Response to #608. 

- **Add Typescript as a dev dependency** Main revision. Add `typescript` to dev dependencies and move `@types` there, too.
- **Add post-install script** Add a script to run after `npm install` to compile Typescript. 
- **Add to .npmignore to reduce package size.** `npm pack` run locally on master produces a tarball at about ~737KB. With the inclusions to `.npmignore` (source code, tests, project configuration) the size is ~389KB or nearly half the size.
- **Update docs and `appveyor.yml`** Remove references to global install and manually running the compile step.
- **Tidy `tsconfig.json`**